### PR TITLE
Update app state when assign_shared_ip_address is present

### DIFF
--- a/provider/appResource.go
+++ b/provider/appResource.go
@@ -208,6 +208,10 @@ func (r *flyAppResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
+	if !plan.AssignSharedIpAddress.IsNull() {
+		data.AssignSharedIpAddress = types.BoolValue(enableSharedIp)
+	}
+
 	diags = resp.State.Set(ctx, data)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
First of all thanks for forking the deprecated provider. We have recently migrated to this one and incurred into one issue concerning pre-existing apps and the lack of the `assign_shared_ip_address` attribute.

The existing conditional in `Update` would not cover the case where the state has a `null` value and the plan has `false`, giving the following error:
```
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to fly_app.xxx, provider "provider[\"registry.terraform.io/andrewbaxter/fly\"]" produced an unexpected new value: .assign_shared_ip_address: was cty.False, but now null.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
I have simply added a check for its presence and update the state accordingly.