### PR TITLE
chore: Update README with registry link, and markdown heading for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This was forked from the [original provider](https://github.com/fly-apps/terrafo
 
 I'm not actively using Fly at the moment - I'll try to fix things if I have time, but otherwise I hope I'll be prompt in reviewing and merging PRs.
 
+## Terraform Registry - andrewbaxter/fly
+
+Terraform resources are documented on the Terraform Registry, published to [andrewbaxter/fly](https://registry.terraform.io/providers/andrewbaxter/fly/latest/docs).
+
 ## Contributions
 
 My only request is try not to change more than is necessary in a PR (i.e. leave formatting alone, if there are multiple unrelated changes turn them into multiple MRs, etc).


### PR DESCRIPTION
Firstly, thank you for forking the Fly.io Terraform provider, especially given that you are no longer using the platform. Please consider registering for GitHub Sponsorships, it may make it more sustainable to maintain the repository.

It's noticeably difficult to find this GitHub repo by searching the web for "andrewbaxter/fly".

 - This change includes the provider name in a README heading, which will improve search indexing.
 - It also adds a link to the registry from the README, which is it significantly more accessible than GitHub's "website" link in the repository settings.
