### PR TITLE
Bugfix: use correct id attribute when importing volumes

### DIFF
--- a/provider/volumeResource.go
+++ b/provider/volumeResource.go
@@ -228,11 +228,11 @@ func (vr flyVolumeResource) ImportState(ctx context.Context, req resource.Import
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: app_id,volume_internal_id. Got: %q", req.ID),
+			fmt.Sprintf("Expected import identifier with format: app_id,volume_id. Got: %q", req.ID),
 		)
 		return
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("internalid"), idParts[1])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
 }


### PR DESCRIPTION
This PR updates the volume import by using the correct id attribute. 

Fixes: https://github.com/andrewbaxter/terraform-provider-fly/issues/7