### PR TITLE
Machine api error reporting, consistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/Khan/genqlient v0.6.0
+	github.com/hashicorp/go-hclog v1.6.1
 	github.com/hashicorp/terraform-plugin-framework v1.4.2
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
@@ -22,7 +23,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/pprof v0.0.0-20231205033806-a5a03c77bf08 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-hclog v1.6.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/machineapi/machines.go
+++ b/machineapi/machines.go
@@ -2,14 +2,14 @@ package machineapi
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/Khan/genqlient/graphql"
 	"github.com/andrewbaxter/terraform-provider-fly/providerstate"
 	"github.com/andrewbaxter/terraform-provider-fly/utils"
+	"github.com/hashicorp/go-hclog"
 	hreq "github.com/imroc/req/v3"
 	"github.com/superfly/flyctl/api"
 )
@@ -17,7 +17,6 @@ import (
 var NonceHeader = "fly-machine-lease-nonce"
 
 type MachineAPI struct {
-	client     *graphql.Client
 	HttpClient *hreq.Client
 	baseUrl    string
 }
@@ -168,156 +167,157 @@ func NewMachineApi(ctx context.Context, state *providerstate.State) *MachineAPI 
 	return out
 }
 
-func (a *MachineAPI) LockMachine(app string, id string, timeout int) (*MachineLease, error) {
-	var res MachineLease
-	_, err := a.HttpClient.R().SetSuccessResult(&res).Post(fmt.Sprintf("%s/v1/apps/%s/machines/%s/lease?ttl=%d", a.baseUrl, app, id, timeout))
+func reqNoBody[O any](ctx context.Context, a *MachineAPI, url string, method string) (*O, error) {
+	return reqFull[any, O](ctx, a, url, method, nil, nil)
+}
+
+func req[I any, O any](ctx context.Context, a *MachineAPI, url string, method string, reqBody I) (*O, error) {
+	return reqFull[I, O](ctx, a, url, method, nil, &reqBody)
+}
+
+func reqFull[I any, O any](ctx context.Context, a *MachineAPI, url string, method string, headers map[string]string, reqBody *I) (*O, error) {
+	var res O
+	var errBody any
+	req := a.HttpClient.R().SetContext(ctx)
+	if headers != nil {
+		req.
+			SetHeaders(headers)
+	}
+	if reqBody != nil {
+		req.SetBody(*reqBody)
+	}
+	req.SetSuccessResult(&res)
+	req.SetErrorResult(&errBody)
+	_, err := req.Send(method, url)
 	if err != nil {
-		return nil, err
+		errBodyJson, _ := json.MarshalIndent(errBody, "", "   ")
+		return nil, fmt.Errorf("API error [%s] to [%s]: %s\nResponse body: %s", url, method, err, string(errBodyJson))
 	}
 	return &res, nil
 }
 
-func (a *MachineAPI) ReleaseMachine(lease MachineLease, app string, id string) error {
-	_, err := a.HttpClient.R().SetHeader(NonceHeader, lease.Data.Nonce).Delete(fmt.Sprintf("%s/v1/apps/%s/machines/%s/lease", a.baseUrl, app, id))
-	if err != nil {
-		return err
-	}
-	return nil
+func (a *MachineAPI) LockMachine(ctx context.Context, app string, id string, timeout int) (*MachineLease, error) {
+	return reqNoBody[MachineLease](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s/lease?ttl=%d", a.baseUrl, app, id, timeout), http.MethodPost)
 }
 
-func (a *MachineAPI) WaitForMachine(app string, id string, instanceID string) error {
-	_, err := a.HttpClient.R().Get(fmt.Sprintf("%s/v1/apps/%s/machines/%s/wait?instance_id=%s", a.baseUrl, app, id, instanceID))
+func (a *MachineAPI) ReleaseMachine(ctx context.Context, lease MachineLease, app string, id string) error {
+	_, err := reqNoBody[any](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s/lease", a.baseUrl, app, id), http.MethodDelete)
+	return err
+}
+
+func (a *MachineAPI) WaitForMachine(ctx context.Context, app string, id string, instanceID string) error {
+	_, err := reqNoBody[any](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s/wait?instance_id=%s", a.baseUrl, app, id, instanceID), http.MethodGet)
 	return err
 }
 
 // CreateMachine takes a MachineCreateOrUpdateRequest and creates the requested machine in the given app and then writes the response into the `res` param
-func (a *MachineAPI) CreateMachine(req MachineCreateOrUpdateRequest, app string, res *MachineResponse) error {
-	if req.Config.Guest.CpuType == "" {
-		req.Config.Guest.CpuType = "shared"
+func (a *MachineAPI) CreateMachine(ctx context.Context, reqBody MachineCreateOrUpdateRequest, app string) (*MachineResponse, error) {
+	if reqBody.Config.Guest.CpuType == "" {
+		reqBody.Config.Guest.CpuType = "shared"
 	}
-	if req.Config.Guest.Cpus == 0 {
-		req.Config.Guest.Cpus = 1
+	if reqBody.Config.Guest.Cpus == 0 {
+		reqBody.Config.Guest.Cpus = 1
 	}
-	if req.Config.Guest.MemoryMb == 0 {
-		req.Config.Guest.MemoryMb = 256
+	if reqBody.Config.Guest.MemoryMb == 0 {
+		reqBody.Config.Guest.MemoryMb = 256
 	}
-	createResponse, err := a.HttpClient.R().SetBody(req).SetSuccessResult(res).Post(fmt.Sprintf("%s/v1/apps/%s/machines", a.baseUrl, app))
-
-	if err != nil {
-		return err
-	}
-
-	if createResponse.StatusCode != http.StatusCreated && createResponse.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("Create request failed: %s, %+v", createResponse.Status, createResponse))
-	}
-	return nil
+	return req[MachineCreateOrUpdateRequest, MachineResponse](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines", a.baseUrl, app), http.MethodPost, reqBody)
 }
 
-func (a *MachineAPI) UpdateMachine(req MachineCreateOrUpdateRequest, app string, id string, res *MachineResponse) error {
-	if req.Config.Guest.CpuType == "" {
-		req.Config.Guest.CpuType = "shared"
+func (a *MachineAPI) UpdateMachine(ctx context.Context, reqBody MachineCreateOrUpdateRequest, app string, id string, res *MachineResponse) error {
+	if reqBody.Config.Guest.CpuType == "" {
+		reqBody.Config.Guest.CpuType = "shared"
 	}
-	if req.Config.Guest.Cpus == 0 {
+	if reqBody.Config.Guest.Cpus == 0 {
 		//You can't have a machine with no cpus
-		req.Config.Guest.Cpus = 1
+		reqBody.Config.Guest.Cpus = 1
 	}
-	if req.Config.Guest.MemoryMb == 0 {
+	if reqBody.Config.Guest.MemoryMb == 0 {
 		//You can't have a machine with no memory
-		req.Config.Guest.MemoryMb = 256
+		reqBody.Config.Guest.MemoryMb = 256
 	}
-	lease, err := a.LockMachine(app, id, 30)
+	lease, err := a.LockMachine(ctx, app, id, 30)
 	if err != nil {
 		return err
 	}
-	reqRes, err := a.HttpClient.R().SetBody(req).SetSuccessResult(res).SetHeader(NonceHeader, lease.Data.Nonce).Post(fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id))
+	defer func() {
+		err := a.ReleaseMachine(ctx, *lease, app, id)
+		if err != nil {
+			hclog.Default().Error("Error releasing lock on app [%s] machine [%s]: %s", app, id, err)
+		}
+	}()
+	_, err = reqFull[MachineCreateOrUpdateRequest, MachineResponse](
+		ctx,
+		a,
+		fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id),
+		http.MethodPost,
+		map[string]string{
+			NonceHeader: lease.Data.Nonce,
+		},
+		&reqBody,
+	)
 	if err != nil {
 		return err
-	}
-	err = a.ReleaseMachine(*lease, app, id)
-	if err != nil {
-		return err
-	}
-	if reqRes.StatusCode != http.StatusCreated && reqRes.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("Update request failed: %s, %+v", reqRes.Status, reqRes))
 	}
 	return nil
 }
 
-func (a *MachineAPI) ReadMachine(app string, id string, res *MachineResponse) (*hreq.Response, error) {
-	return a.HttpClient.R().SetSuccessResult(res).Get(fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id))
+func (a *MachineAPI) ReadMachine(ctx context.Context, app string, id string) (*MachineResponse, error) {
+	return reqNoBody[MachineResponse](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id), http.MethodGet)
 }
 
-func (a *MachineAPI) DeleteMachine(app string, id string, maxRetries int) error {
-	deleted := false
+func (a *MachineAPI) DeleteMachine(ctx context.Context, app string, id string, maxRetries int) error {
 	for i := 0; i < maxRetries; i++ {
-		var machine MachineResponse
-		readResponse, err := a.HttpClient.R().SetSuccessResult(&machine).Get(fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id))
+		machine, err := reqNoBody[MachineResponse](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id), http.MethodGet)
 		if err != nil {
 			return err
 		}
 
-		if readResponse.StatusCode == 200 {
-			if machine.State == "started" || machine.State == "starting" || machine.State == "replacing" {
-				_, _ = a.HttpClient.R().Post(fmt.Sprintf("%s/v1/apps/%s/machines/%s/stop", a.baseUrl, app, id))
+		switch machine.State {
+		case "started", "starting":
+			_, err := reqNoBody[MachineResponse](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s/stop", a.baseUrl, app, id), http.MethodPost)
+			if err != nil {
+				return err
 			}
-			if machine.State == "stopping" || machine.State == "destroying" {
-				time.Sleep(5 * time.Second)
+		case "stopping", "destroying", "replacing":
+			time.Sleep(5 * time.Second)
+		case "stopped", "replaced":
+			_, err := reqNoBody[MachineResponse](ctx, a, fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id), http.MethodDelete)
+			if err != nil {
+				return err
 			}
-			if machine.State == "stopped" || machine.State == "replaced" {
-				_, err = a.HttpClient.R().Delete(fmt.Sprintf("%s/v1/apps/%s/machines/%s", a.baseUrl, app, id))
-				if err != nil {
-					return err
-				}
-			}
-			if machine.State == "destroyed" {
-				deleted = true
-				break
-			}
+		case "destroyed":
+			return nil
 		}
 	}
-	if !deleted {
-		return errors.New("max retries exceeded")
-	}
-	return nil
+	return fmt.Errorf("reached max attempts while trying to delete app %s machine %s", app, id)
 }
 
 func (a *MachineAPI) CreateVolume(ctx context.Context, name, app, region string, size int) (*api.Volume, error) {
-	var res api.Volume
-	_, err := a.HttpClient.R().SetContext(ctx).SetBody(api.CreateVolumeRequest{
-		Name:   name,
-		Region: region,
-		SizeGb: &size,
-	}).SetSuccessResult(&res).Post(fmt.Sprintf("%s/v1/apps/%s/volumes", a.baseUrl, app))
-	if err != nil {
-		return nil, err
-	}
-	return &res, nil
+	return req[api.CreateVolumeRequest, api.Volume](
+		ctx,
+		a,
+		fmt.Sprintf("%s/v1/apps/%s/volumes", a.baseUrl, app),
+		http.MethodPost, api.CreateVolumeRequest{
+			Name:   name,
+			Region: region,
+			SizeGb: &size,
+		},
+	)
 }
 
 func (a *MachineAPI) GetVolume(ctx context.Context, id, app string) (*api.Volume, error) {
-	var res api.Volume
-	_, err := a.HttpClient.R().SetContext(ctx).SetSuccessResult(&res).Get(fmt.Sprintf("%s/v1/apps/%s/volumes/%s", a.baseUrl, app, id))
-	if err != nil {
-		return nil, err
-	}
-
-	return &res, nil
+	return reqNoBody[api.Volume](ctx, a, fmt.Sprintf("%s/v1/apps/%s/volumes/%s", a.baseUrl, app, id), http.MethodGet)
 }
 
 func (a *MachineAPI) ExtendVolume(ctx context.Context, app string, id string, size int) error {
-	_, err := a.HttpClient.R().SetContext(ctx).SetBody(map[string]any{
+	_, err := req[map[string]any, any](ctx, a, fmt.Sprintf("%s/v1/apps/%s/volumes/%s/extend", a.baseUrl, app, id), http.MethodPut, map[string]any{
 		"size_gb": size,
-	}).Put(fmt.Sprintf("%s/v1/apps/%s/volumes/%s/extend", a.baseUrl, app, id))
-	if err != nil {
-		return err
-	}
-	return nil
+	})
+	return err
 }
 
 func (a *MachineAPI) DeleteVolume(ctx context.Context, app string, id string) error {
-	_, err := a.HttpClient.R().SetContext(ctx).Delete(fmt.Sprintf("%s/v1/apps/%s/volumes/%s", a.baseUrl, app, id))
-	if err != nil {
-		return err
-	}
-	return nil
+	_, err := reqNoBody[any](ctx, a, fmt.Sprintf("%s/v1/apps/%s/volumes/%s", a.baseUrl, app, id), http.MethodDelete)
+	return err
 }

--- a/provider/certificateResource.go
+++ b/provider/certificateResource.go
@@ -147,7 +147,6 @@ func (r *flyCertResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 func (cr *flyCertResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	resp.Diagnostics.AddError("The fly api does not allow updating certs once created", "Try deleting and then recreating the cert with new options")
-	return
 	// We could maybe instead flag every attribute with RequiresReplace?
 }
 

--- a/provider/ipResource.go
+++ b/provider/ipResource.go
@@ -162,7 +162,6 @@ func (r *flyIpResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		"The fly api does not allow updating ips once created",
 		"Try deleting and then recreating the ip with new options",
 	)
-	return
 }
 
 func (r *flyIpResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/provider/machineResource.go
+++ b/provider/machineResource.go
@@ -351,8 +351,7 @@ func (r *flyMachineResource) Create(ctx context.Context, req resource.CreateRequ
 
 	machineApi := machineapi.NewMachineApi(ctx, r.state)
 
-	var newMachine machineapi.MachineResponse
-	err := machineApi.CreateMachine(createReq, data.App.ValueString(), &newMachine)
+	newMachine, err := machineApi.CreateMachine(ctx, createReq, data.App.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create machine", err.Error())
 		return
@@ -399,7 +398,7 @@ func (r *flyMachineResource) Create(ctx context.Context, req resource.CreateRequ
 		data.Mounts = tfmounts
 	}
 
-	err = machineApi.WaitForMachine(data.App.ValueString(), data.Id.ValueString(), newMachine.InstanceID)
+	err = machineApi.WaitForMachine(ctx, data.App.ValueString(), data.Id.ValueString(), newMachine.InstanceID)
 	if err != nil {
 		//FIXME(?): For now we just assume that the orchestrator is in fact going to faithfully execute our request
 		tflog.Info(ctx, "Waiting errored")
@@ -420,9 +419,7 @@ func (r *flyMachineResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	machineApi := machineapi.NewMachineApi(ctx, r.state)
 
-	var machine machineapi.MachineResponse
-
-	_, err := machineApi.ReadMachine(data.App.ValueString(), data.Id.ValueString(), &machine)
+	machine, err := machineApi.ReadMachine(ctx, data.App.ValueString(), data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create machine", err.Error())
 		return
@@ -549,7 +546,7 @@ func (r *flyMachineResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	var updatedMachine machineapi.MachineResponse
 
-	err := machineApi.UpdateMachine(updateReq, state.App.ValueString(), state.Id.ValueString(), &updatedMachine)
+	err := machineApi.UpdateMachine(ctx, updateReq, state.App.ValueString(), state.Id.ValueString(), &updatedMachine)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to update machine", err.Error())
 		return
@@ -597,7 +594,7 @@ func (r *flyMachineResource) Update(ctx context.Context, req resource.UpdateRequ
 		state.Mounts = tfmounts
 	}
 
-	err = machineApi.WaitForMachine(state.App.ValueString(), state.Id.ValueString(), updatedMachine.InstanceID)
+	err = machineApi.WaitForMachine(ctx, state.App.ValueString(), state.Id.ValueString(), updatedMachine.InstanceID)
 	if err != nil {
 		tflog.Info(ctx, "Waiting errored")
 	}
@@ -619,7 +616,7 @@ func (r *flyMachineResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	machineApi := machineapi.NewMachineApi(ctx, r.state)
 
-	err := machineApi.DeleteMachine(data.App.ValueString(), data.Id.ValueString(), 50)
+	err := machineApi.DeleteMachine(ctx, data.App.ValueString(), data.Id.ValueString(), 50)
 	if err != nil {
 		resp.Diagnostics.AddError("Machine delete failed", err.Error())
 		return


### PR DESCRIPTION
Fix #13 

In order to do this consistently I rewrote the machine api with some higher level request methods that handle logging error responses.  Also did stuff like passing contexts through, using defer for unlock, using return values for return values, etc.  And some random cleanup go started warning me about.

I haven't had the chance to test this yet and it's a fairly significant change.  If someone else wants to try it and confirm it works I'll go ahead and release though.

If you want to try it:
1. Clone
2. `./build.sh` (or just `go build`)
3. Make a file like:

```
$ cat ~/.terraformrc 
provider_installation {
  dev_overrides {
      "andrewbaxter/fly" = "/path/to/clone/dir"
  }
  direct {}
}
```

then run terraform normally.  You can comment out the line (`//`) to go back to upstream.