### PR TITLE
fix(datasource): fly_ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ infra/terraform.tfvars
 examples/local/
 tmp/
 .history/
+vendor/

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -xeu
+#!/usr/bin/env bash -xeu
 go run -modfile tools.mod github.com/Khan/genqlient graphql/genqlient.yaml
 go build
 rm -rf docs

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -923,6 +923,36 @@ const (
 	IPAddressTypeSharedV4  IPAddressType = "shared_v4"
 )
 
+// IpAddressByIdQueryIpAddressIPAddress includes the requested fields of the GraphQL type IPAddress.
+type IpAddressByIdQueryIpAddressIPAddress struct {
+	Id      string        `json:"id"`
+	Type    IPAddressType `json:"type"`
+	Address string        `json:"address"`
+	Region  string        `json:"region"`
+}
+
+// GetId returns IpAddressByIdQueryIpAddressIPAddress.Id, and is useful for accessing the field via an interface.
+func (v *IpAddressByIdQueryIpAddressIPAddress) GetId() string { return v.Id }
+
+// GetType returns IpAddressByIdQueryIpAddressIPAddress.Type, and is useful for accessing the field via an interface.
+func (v *IpAddressByIdQueryIpAddressIPAddress) GetType() IPAddressType { return v.Type }
+
+// GetAddress returns IpAddressByIdQueryIpAddressIPAddress.Address, and is useful for accessing the field via an interface.
+func (v *IpAddressByIdQueryIpAddressIPAddress) GetAddress() string { return v.Address }
+
+// GetRegion returns IpAddressByIdQueryIpAddressIPAddress.Region, and is useful for accessing the field via an interface.
+func (v *IpAddressByIdQueryIpAddressIPAddress) GetRegion() string { return v.Region }
+
+// IpAddressByIdQueryResponse is returned by IpAddressByIdQuery on success.
+type IpAddressByIdQueryResponse struct {
+	IpAddress IpAddressByIdQueryIpAddressIPAddress `json:"ipAddress"`
+}
+
+// GetIpAddress returns IpAddressByIdQueryResponse.IpAddress, and is useful for accessing the field via an interface.
+func (v *IpAddressByIdQueryResponse) GetIpAddress() IpAddressByIdQueryIpAddressIPAddress {
+	return v.IpAddress
+}
+
 // IpAddressQueryApp includes the requested fields of the GraphQL type App.
 type IpAddressQueryApp struct {
 	IpAddress IpAddressQueryAppIpAddressIPAddress `json:"ipAddress"`
@@ -1347,6 +1377,14 @@ type __GetFullAppInput struct {
 
 // GetName returns __GetFullAppInput.Name, and is useful for accessing the field via an interface.
 func (v *__GetFullAppInput) GetName() string { return v.Name }
+
+// __IpAddressByIdQueryInput is used internally by genqlient
+type __IpAddressByIdQueryInput struct {
+	Id string `json:"id"`
+}
+
+// GetId returns __IpAddressByIdQueryInput.Id, and is useful for accessing the field via an interface.
+func (v *__IpAddressByIdQueryInput) GetId() string { return v.Id }
 
 // __IpAddressQueryInput is used internally by genqlient
 type __IpAddressQueryInput struct {
@@ -1873,6 +1911,44 @@ func GetFullApp(
 	var err error
 
 	var data GetFullAppResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by IpAddressByIdQuery.
+const IpAddressByIdQuery_Operation = `
+query IpAddressByIdQuery ($id: ID!) {
+	ipAddress(id: $id) {
+		id
+		type
+		address
+		region
+	}
+}
+`
+
+func IpAddressByIdQuery(
+	ctx context.Context,
+	client graphql.Client,
+	id string,
+) (*IpAddressByIdQueryResponse, error) {
+	req := &graphql.Request{
+		OpName: "IpAddressByIdQuery",
+		Query:  IpAddressByIdQuery_Operation,
+		Variables: &__IpAddressByIdQueryInput{
+			Id: id,
+		},
+	}
+	var err error
+
+	var data IpAddressByIdQueryResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/graphql/genqlient.graphql
+++ b/graphql/genqlient.graphql
@@ -145,6 +145,15 @@ query IpAddressQuery($app: String, $addr: String!) {
   }
 }
 
+query IpAddressByIdQuery($id: ID!) {
+  ipAddress(id: $id) {
+    id
+    type
+    address
+    region
+  }
+}
+
 mutation AllocateIpAddress(
   $app: ID!
   $region: String

--- a/provider/ipDataSource.go
+++ b/provider/ipDataSource.go
@@ -80,21 +80,22 @@ func (d *ipDataSourceType) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	addr := data.Address.ValueString()
+	id := data.Id.ValueString()
 	app := data.App.ValueString()
-	query, err := graphql.IpAddressQuery(ctx, d.state.GraphqlClient, app, addr)
-	tflog.Info(ctx, fmt.Sprintf("Query res: for %s %s %+v", app, addr, query))
+	query, err := graphql.IpAddressByIdQuery(ctx, d.state.GraphqlClient, id)
+	tflog.Info(ctx, fmt.Sprintf("Query res: for app %s id %s %+v", app, id, query))
 	if err != nil {
-		utils.HandleGraphqlErrors(&resp.Diagnostics, err, "Error looking up ip address (app [%s], addr [%s])", app, addr)
+		utils.HandleGraphqlErrors(&resp.Diagnostics, err, "Error looking up ip address (app [%s], id [%s])", app, id)
 		return
 	}
 
-	region := query.App.IpAddress.Region
+	region := query.IpAddress.Region
 	if region == "" {
 		region = "global"
 	}
 	data.Region = types.StringValue(region)
-	data.Address = types.StringValue(query.App.IpAddress.Address)
+	data.Address = types.StringValue(query.IpAddress.Address)
+	data.Type = types.StringValue(string(query.IpAddress.Type))
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Hey @andrewbaxter,

Thanks for maintaining this repository.
I have been using it lately and came across some issues/inconsistencies between docs and actual provider method, it seems `fly_ip` datasource ask for `id` but in the code base it tries to match within `ipAddress`.

here's how to reproduce: 
in my terraform manifest :
```terraform
data "fly_app" "test_app" {
  name = "test_app"
}

data "fly_ip" "test_app" {
  app = data.fly_app.test_app.name
  id = "ip_REDACTED"
}

output "fly_ip" {
  value = data.fly_ip.test_app
}
```

ends up in : 
```bash
$ terraform plan
data.fly_app.test_app: Reading...
data.fly_app.test_app: Read complete after 1s [id=test_app]
data.fly_ip.test_app: Reading...

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Error looking up ip address (app [test_app], addr [])
│
│   with data.fly_ip.test_app,
│   on main.tf line 5, in data "fly_ip" "test_app":
│    5: data "fly_ip" "test_app" {
│
│ Upstream graphql error: Could not find IPAssignment
│ Graphql path: app.ipAddress

```

the actual fix is align with the actual [doc](https://registry.terraform.io/providers/andrewbaxter/fly/0.1.18/docs/data-sources/ip)
<img width="661" height="338" alt="image" src="https://github.com/user-attachments/assets/7ddffa43-f8fd-432e-84a0-7bd42abd6412" />

it seems to work locally after compiling the binary.

hopefully this helps
